### PR TITLE
Initialize project skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY backend/requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+COPY backend/app app
+CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# quizBot
+# QuizBot
+
+This project provides a skeleton implementation for a real-time quiz platform using Flask, Socket.IO and PostgreSQL. It illustrates the main components required for the service described in the system prompt.
+
+## Architecture Overview
+
+- **Backend**: Flask application with Flask-SocketIO and SQLAlchemy.
+- **Database**: PostgreSQL (via SQLAlchemy) and Redis for WebSocket message broker.
+- **Frontend**: Static files served from `frontend/` (not yet implemented).
+- **Deployment**: Docker containers orchestrated by `docker-compose`.
+
+## File Structure
+
+```
+backend/
+  app/
+    __init__.py      # creates Flask app, registers Socket.IO
+    config.py        # configuration settings
+    models.py        # database models
+    routes.py        # REST API endpoints
+    sockets.py       # WebSocket handlers
+  requirements.txt   # Python dependencies
+frontend/            # placeholder for client-side code
+Dockerfile           # container for the Flask app
+docker-compose.yml   # local development stack
+```
+
+## Setup
+
+1. **Build containers**
+
+```bash
+docker-compose build
+```
+
+2. **Start stack**
+
+```bash
+docker-compose up
+```
+
+The API will be available at <http://localhost:5000>.
+
+## Development Notes
+
+- Models include `Quiz`, `Question`, `Choice`, `Participant` and `Answer`.
+- `routes.py` exposes basic endpoints for joining a quiz and starting a session.
+- `sockets.py` contains placeholder handlers for real-time events.
+- Configuration defaults to SQLite for development; override `DATABASE_URL` for production.
+
+## Next Steps
+
+This repository only contains a minimal skeleton. Additional work is required to implement the full feature set, such as:
+
+- Completing WebSocket logic for question delivery and answer validation.
+- Building the organizer dashboard and participant views in `frontend/`.
+- Adding authentication (JWT), file uploads and analytics exports.
+- Creating unit and integration tests to reach the desired coverage.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,19 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_socketio import SocketIO
+from .config import Config
+
+db = SQLAlchemy()
+socketio = SocketIO(cors_allowed_origins='*')
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    db.init_app(app)
+    socketio.init_app(app, message_queue=app.config.get('REDIS_URL'))
+
+    from . import routes, sockets
+    app.register_blueprint(routes.bp)
+    sockets.register_socketio_events(socketio)
+
+    return app

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,7 @@
+import os
+
+class Config:
+    SECRET_KEY = os.getenv('SECRET_KEY', 'change-me')
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///quiz.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    REDIS_URL = os.getenv('REDIS_URL', 'redis://redis:6379/0')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from sqlalchemy import Enum
+from . import db
+
+class Quiz(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text)
+    short_code = db.Column(db.String(8), unique=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Question(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    quiz_id = db.Column(db.Integer, db.ForeignKey('quiz.id'), nullable=False)
+    text = db.Column(db.Text, nullable=False)
+    qtype = db.Column(Enum('tf', 'single', 'text', 'numeric', name='qtype'), nullable=False)
+    time_limit = db.Column(db.Integer, default=30)
+    media_url = db.Column(db.String(255))
+    order = db.Column(db.Integer)
+    quiz = db.relationship('Quiz', backref=db.backref('questions', lazy=True))
+
+class Choice(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    question_id = db.Column(db.Integer, db.ForeignKey('question.id'), nullable=False)
+    text = db.Column(db.String(255))
+    is_correct = db.Column(db.Boolean, default=False)
+    question = db.relationship('Question', backref=db.backref('choices', lazy=True))
+
+class Participant(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), nullable=False)
+    quiz_id = db.Column(db.Integer, db.ForeignKey('quiz.id'), nullable=False)
+    session_id = db.Column(db.String(36), unique=True)
+    score = db.Column(db.Integer, default=0)
+    quiz = db.relationship('Quiz', backref=db.backref('participants', lazy=True))
+
+class Answer(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    participant_id = db.Column(db.Integer, db.ForeignKey('participant.id'), nullable=False)
+    question_id = db.Column(db.Integer, db.ForeignKey('question.id'), nullable=False)
+    value = db.Column(db.Text)
+    correct = db.Column(db.Boolean)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, request, jsonify
+from . import db
+from .models import Quiz, Participant
+
+bp = Blueprint('api', __name__)
+
+@bp.route('/join/<short_code>', methods=['POST'])
+def join(short_code):
+    name = request.json.get('name')
+    quiz = Quiz.query.filter_by(short_code=short_code).first_or_404()
+    participant = Participant(name=name, quiz=quiz)
+    db.session.add(participant)
+    db.session.commit()
+    return jsonify({'participant_id': participant.id})
+
+@bp.route('/api/quizzes/<int:quiz_id>/start_session', methods=['POST'])
+def start_session(quiz_id):
+    quiz = Quiz.query.get_or_404(quiz_id)
+    # This would trigger a SocketIO event in real implementation
+    return jsonify({'status': 'started', 'quiz_id': quiz.id})

--- a/backend/app/sockets.py
+++ b/backend/app/sockets.py
@@ -1,0 +1,11 @@
+from .models import Participant, Question
+from . import db
+
+def register_socketio_events(socketio):
+    @socketio.on('submit_answer')
+    def handle_submit(data):
+        participant_id = data.get('participant_id')
+        question_id = data.get('question_id')
+        value = data.get('value')
+        # TODO: validate and update score
+        pass

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+Flask>=2.2
+Flask-SocketIO
+SQLAlchemy
+psycopg2-binary
+redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      - FLASK_APP=app
+    volumes:
+      - ./backend/app:/app/app
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: quiz
+      POSTGRES_PASSWORD: quiz
+      POSTGRES_DB: quiz
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
## Summary
- set up Flask application skeleton and Docker config
- add basic SQLAlchemy models and endpoints
- provide docker-compose for local development
- document architecture and setup steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5d8fe71c832bb69f863dafabbdf4