### PR TITLE
Implement Quiz CRUD with migrations and tests

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,26 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///quiz.db
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,15 +1,18 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_socketio import SocketIO
+from flask_migrate import Migrate
 from .config import Config
 
 db = SQLAlchemy()
+migrate = Migrate()
 socketio = SocketIO(cors_allowed_origins='*')
 
 def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
     db.init_app(app)
+    migrate.init_app(app, db)
     socketio.init_app(app, message_queue=app.config.get('REDIS_URL'))
 
     from . import routes, sockets

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -6,38 +6,66 @@ class Quiz(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(255), nullable=False)
     description = db.Column(db.Text)
-    short_code = db.Column(db.String(8), unique=True, nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    short_code = db.Column(db.String(8), unique=True, nullable=False, index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
 
 class Question(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    quiz_id = db.Column(db.Integer, db.ForeignKey('quiz.id'), nullable=False)
+    quiz_id = db.Column(
+        db.Integer, db.ForeignKey('quiz.id'), nullable=False, index=True
+    )
     text = db.Column(db.Text, nullable=False)
     qtype = db.Column(Enum('tf', 'single', 'text', 'numeric', name='qtype'), nullable=False)
     time_limit = db.Column(db.Integer, default=30)
     media_url = db.Column(db.String(255))
     order = db.Column(db.Integer)
     quiz = db.relationship('Quiz', backref=db.backref('questions', lazy=True))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
 
 class Choice(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    question_id = db.Column(db.Integer, db.ForeignKey('question.id'), nullable=False)
+    question_id = db.Column(
+        db.Integer, db.ForeignKey('question.id'), nullable=False, index=True
+    )
     text = db.Column(db.String(255))
     is_correct = db.Column(db.Boolean, default=False)
     question = db.relationship('Question', backref=db.backref('choices', lazy=True))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
 
 class Participant(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(64), nullable=False)
-    quiz_id = db.Column(db.Integer, db.ForeignKey('quiz.id'), nullable=False)
+    quiz_id = db.Column(
+        db.Integer, db.ForeignKey('quiz.id'), nullable=False, index=True
+    )
     session_id = db.Column(db.String(36), unique=True)
     score = db.Column(db.Integer, default=0)
     quiz = db.relationship('Quiz', backref=db.backref('participants', lazy=True))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
 
 class Answer(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    participant_id = db.Column(db.Integer, db.ForeignKey('participant.id'), nullable=False)
-    question_id = db.Column(db.Integer, db.ForeignKey('question.id'), nullable=False)
+    participant_id = db.Column(
+        db.Integer, db.ForeignKey('participant.id'), nullable=False, index=True
+    )
+    question_id = db.Column(
+        db.Integer, db.ForeignKey('question.id'), nullable=False, index=True
+    )
     value = db.Column(db.Text)
     correct = db.Column(db.Boolean)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,8 +1,17 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, abort
 from . import db
-from .models import Quiz, Participant
+from .models import Quiz, Question, Choice, Participant
+import random
+import string
 
 bp = Blueprint('api', __name__)
+
+def _generate_short_code(length=6):
+    characters = string.ascii_uppercase + string.digits
+    while True:
+        code = ''.join(random.choice(characters) for _ in range(length))
+        if not Quiz.query.filter_by(short_code=code).first():
+            return code
 
 @bp.route('/join/<short_code>', methods=['POST'])
 def join(short_code):
@@ -12,6 +21,177 @@ def join(short_code):
     db.session.add(participant)
     db.session.commit()
     return jsonify({'participant_id': participant.id})
+
+
+@bp.route('/api/quizzes', methods=['GET'])
+def list_quizzes():
+    """Return paginated list of quizzes."""
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 20, type=int)
+    pagination = Quiz.query.paginate(page=page, per_page=per_page, error_out=False)
+    quizzes = [
+        {
+            'id': q.id,
+            'title': q.title,
+            'description': q.description,
+            'short_code': q.short_code,
+        }
+        for q in pagination.items
+    ]
+    return jsonify({'quizzes': quizzes, 'total': pagination.total})
+
+
+@bp.route('/api/quizzes', methods=['POST'])
+def create_quiz():
+    """Create a new quiz."""
+    data = request.get_json() or {}
+    title = data.get('title')
+    if not title:
+        return jsonify({'error': 'title is required'}), 400
+    description = data.get('description')
+    quiz = Quiz(title=title, description=description, short_code=_generate_short_code())
+    db.session.add(quiz)
+    db.session.commit()
+    return jsonify({'id': quiz.id, 'short_code': quiz.short_code}), 201
+
+
+@bp.route('/api/quizzes/<int:quiz_id>', methods=['GET'])
+def get_quiz(quiz_id):
+    """Get quiz details including questions."""
+    quiz = Quiz.query.get_or_404(quiz_id)
+    questions = [
+        {
+            'id': q.id,
+            'text': q.text,
+            'qtype': q.qtype,
+            'time_limit': q.time_limit,
+            'media_url': q.media_url,
+            'order': q.order,
+            'choices': [
+                {'id': c.id, 'text': c.text, 'is_correct': c.is_correct}
+                for c in q.choices
+            ],
+        }
+        for q in quiz.questions
+    ]
+    return jsonify(
+        {
+            'id': quiz.id,
+            'title': quiz.title,
+            'description': quiz.description,
+            'short_code': quiz.short_code,
+            'questions': questions,
+        }
+    )
+
+
+@bp.route('/api/quizzes/<int:quiz_id>', methods=['PUT'])
+def update_quiz(quiz_id):
+    """Update quiz title or description."""
+    quiz = Quiz.query.get_or_404(quiz_id)
+    data = request.get_json() or {}
+    if 'title' in data and not data['title']:
+        return jsonify({'error': 'title cannot be empty'}), 400
+    quiz.title = data.get('title', quiz.title)
+    quiz.description = data.get('description', quiz.description)
+    db.session.commit()
+    return jsonify({'id': quiz.id})
+
+
+@bp.route('/api/quizzes/<int:quiz_id>', methods=['DELETE'])
+def delete_quiz(quiz_id):
+    """Delete quiz."""
+    quiz = Quiz.query.get_or_404(quiz_id)
+    db.session.delete(quiz)
+    db.session.commit()
+    return jsonify({'status': 'deleted'})
+
+
+@bp.route('/api/quizzes/<int:quiz_id>/questions', methods=['POST'])
+def create_question(quiz_id):
+    """Create question for a quiz."""
+    quiz = Quiz.query.get_or_404(quiz_id)
+    data = request.get_json() or {}
+    text = data.get('text')
+    qtype = data.get('qtype')
+    if not text or not qtype:
+        return jsonify({'error': 'text and qtype are required'}), 400
+    question = Question(
+        quiz=quiz,
+        text=text,
+        qtype=qtype,
+        time_limit=data.get('time_limit', 30),
+        media_url=data.get('media_url'),
+        order=data.get('order'),
+    )
+    db.session.add(question)
+    db.session.commit()
+    return jsonify({'id': question.id}), 201
+
+
+@bp.route('/api/questions/<int:question_id>', methods=['PUT'])
+def update_question(question_id):
+    """Update a question."""
+    question = Question.query.get_or_404(question_id)
+    data = request.get_json() or {}
+    if 'text' in data and not data['text']:
+        return jsonify({'error': 'text cannot be empty'}), 400
+    question.text = data.get('text', question.text)
+    question.qtype = data.get('qtype', question.qtype)
+    question.time_limit = data.get('time_limit', question.time_limit)
+    question.media_url = data.get('media_url', question.media_url)
+    db.session.commit()
+    return jsonify({'id': question.id})
+
+
+@bp.route('/api/questions/<int:question_id>', methods=['DELETE'])
+def delete_question(question_id):
+    """Delete question."""
+    question = Question.query.get_or_404(question_id)
+    db.session.delete(question)
+    db.session.commit()
+    return jsonify({'status': 'deleted'})
+
+
+@bp.route('/api/questions/<int:question_id>/choices', methods=['POST'])
+def add_choice(question_id):
+    """Add choice to question."""
+    question = Question.query.get_or_404(question_id)
+    data = request.get_json() or {}
+    text = data.get('text')
+    if text is None:
+        return jsonify({'error': 'text is required'}), 400
+    choice = Choice(
+        question=question,
+        text=text,
+        is_correct=data.get('is_correct', False),
+    )
+    db.session.add(choice)
+    db.session.commit()
+    return jsonify({'id': choice.id}), 201
+
+
+@bp.route('/api/choices/<int:choice_id>', methods=['PUT'])
+def update_choice(choice_id):
+    """Update a choice."""
+    choice = Choice.query.get_or_404(choice_id)
+    data = request.get_json() or {}
+    if 'text' in data and data['text'] is None:
+        return jsonify({'error': 'text cannot be null'}), 400
+    choice.text = data.get('text', choice.text)
+    if 'is_correct' in data:
+        choice.is_correct = data['is_correct']
+    db.session.commit()
+    return jsonify({'id': choice.id})
+
+
+@bp.route('/api/choices/<int:choice_id>', methods=['DELETE'])
+def delete_choice(choice_id):
+    """Delete a choice."""
+    choice = Choice.query.get_or_404(choice_id)
+    db.session.delete(choice)
+    db.session.commit()
+    return jsonify({'status': 'deleted'})
 
 @bp.route('/api/quizzes/<int:quiz_id>/start_session', methods=['POST'])
 def start_session(quiz_id):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,6 @@ Flask-SocketIO
 SQLAlchemy
 psycopg2-binary
 redis
+Flask-Migrate
+pytest
+pytest-cov

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,35 @@
+from __future__ import with_statement
+import logging
+from alembic import context
+from flask import current_app
+
+config = context.config
+
+fileConfig = getattr(logging.config, 'fileConfig', None)
+if fileConfig:
+    fileConfig(config.config_file_name)
+
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+def run_migrations_offline():
+    url = config.get_main_option('sqlalchemy.url')
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = current_app.extensions['migrate'].db.engine
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/0001_create_tables.py
+++ b/migrations/versions/0001_create_tables.py
@@ -1,0 +1,103 @@
+"""initial tables
+
+Revision ID: 0001
+Revises: 
+Create Date: 2025-06-26 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'quiz',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(length=255), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('short_code', sa.String(length=8), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('short_code'),
+    )
+    op.create_index(op.f('ix_quiz_short_code'), 'quiz', ['short_code'], unique=True)
+
+    op.create_table(
+        'question',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('quiz_id', sa.Integer(), nullable=False),
+        sa.Column('text', sa.Text(), nullable=False),
+        sa.Column('qtype', sa.Enum('tf', 'single', 'text', 'numeric', name='qtype'), nullable=False),
+        sa.Column('time_limit', sa.Integer(), nullable=True),
+        sa.Column('media_url', sa.String(length=255), nullable=True),
+        sa.Column('order', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['quiz_id'], ['quiz.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_question_quiz_id'), 'question', ['quiz_id'], unique=False)
+
+    op.create_table(
+        'choice',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('question_id', sa.Integer(), nullable=False),
+        sa.Column('text', sa.String(length=255), nullable=True),
+        sa.Column('is_correct', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['question_id'], ['question.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_choice_question_id'), 'choice', ['question_id'], unique=False)
+
+    op.create_table(
+        'participant',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=64), nullable=False),
+        sa.Column('quiz_id', sa.Integer(), nullable=False),
+        sa.Column('session_id', sa.String(length=36), nullable=True),
+        sa.Column('score', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['quiz_id'], ['quiz.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('session_id')
+    )
+    op.create_index(op.f('ix_participant_quiz_id'), 'participant', ['quiz_id'], unique=False)
+
+    op.create_table(
+        'answer',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('participant_id', sa.Integer(), nullable=False),
+        sa.Column('question_id', sa.Integer(), nullable=False),
+        sa.Column('value', sa.Text(), nullable=True),
+        sa.Column('correct', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['participant_id'], ['participant.id'], ),
+        sa.ForeignKeyConstraint(['question_id'], ['question.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_answer_participant_id'), 'answer', ['participant_id'], unique=False)
+    op.create_index(op.f('ix_answer_question_id'), 'answer', ['question_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_answer_question_id'), table_name='answer')
+    op.drop_index(op.f('ix_answer_participant_id'), table_name='answer')
+    op.drop_table('answer')
+    op.drop_index(op.f('ix_participant_quiz_id'), table_name='participant')
+    op.drop_table('participant')
+    op.drop_index(op.f('ix_choice_question_id'), table_name='choice')
+    op.drop_table('choice')
+    op.drop_index(op.f('ix_question_quiz_id'), table_name='question')
+    op.drop_table('question')
+    op.drop_index(op.f('ix_quiz_short_code'), table_name='quiz')
+    op.drop_table('quiz')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'backend')))
+from app import create_app, db as _db
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.session.remove()
+        _db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,35 @@
+from app.models import Quiz, Question, Choice, Participant, Answer
+from app import db
+
+
+def test_quiz_creation(app):
+    quiz = Quiz(title='Sample', description='desc', short_code='ABC123')
+    db.session.add(quiz)
+    db.session.commit()
+    assert quiz.id is not None
+    assert quiz.created_at is not None
+    assert quiz.updated_at is not None
+
+
+def test_question_relationship(app):
+    quiz = Quiz(title='q', description='d', short_code='CODE1')
+    db.session.add(quiz)
+    db.session.commit()
+    q = Question(quiz=quiz, text='Q', qtype='tf')
+    db.session.add(q)
+    db.session.commit()
+    assert q.quiz_id == quiz.id
+
+
+def test_choice_relationship(app):
+    quiz = Quiz(title='q', description='d', short_code='CODE2')
+    db.session.add(quiz)
+    db.session.commit()
+    ques = Question(quiz=quiz, text='Q', qtype='tf')
+    db.session.add(ques)
+    db.session.commit()
+    ch = Choice(question=ques, text='A', is_correct=True)
+    db.session.add(ch)
+    db.session.commit()
+    assert ch.question_id == ques.id
+

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,60 @@
+import json
+from app.models import Quiz, Question, Choice
+from app import db
+
+
+def create_quiz(client, title='Quiz 1'):
+    res = client.post('/api/quizzes', json={'title': title, 'description': 'd'})
+    assert res.status_code == 201
+    return res.get_json()['id']
+
+
+def test_create_get_update_delete_quiz(client):
+    qid = create_quiz(client)
+    # get
+    res = client.get(f'/api/quizzes/{qid}')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data['title'] == 'Quiz 1'
+
+    # update
+    res = client.put(f'/api/quizzes/{qid}', json={'title': 'New'})
+    assert res.status_code == 200
+    res = client.get(f'/api/quizzes/{qid}')
+    assert res.get_json()['title'] == 'New'
+
+    # delete
+    res = client.delete(f'/api/quizzes/{qid}')
+    assert res.status_code == 200
+    res = client.get(f'/api/quizzes/{qid}')
+    assert res.status_code == 404
+
+
+def test_question_crud(client):
+    qid = create_quiz(client)
+    res = client.post(f'/api/quizzes/{qid}/questions', json={'text': 'Q?', 'qtype': 'tf'})
+    assert res.status_code == 201
+    ques_id = res.get_json()['id']
+
+    res = client.put(f'/api/questions/{ques_id}', json={'text': 'New?', 'time_limit': 10})
+    assert res.status_code == 200
+
+    res = client.delete(f'/api/questions/{ques_id}')
+    assert res.status_code == 200
+
+
+def test_choice_crud(client):
+    qid = create_quiz(client)
+    res = client.post(f'/api/quizzes/{qid}/questions', json={'text': 'Q?', 'qtype': 'single'})
+    question_id = res.get_json()['id']
+
+    res = client.post(f'/api/questions/{question_id}/choices', json={'text': 'A', 'is_correct': True})
+    assert res.status_code == 201
+    choice_id = res.get_json()['id']
+
+    res = client.put(f'/api/choices/{choice_id}', json={'text': 'B'})
+    assert res.status_code == 200
+
+    res = client.delete(f'/api/choices/{choice_id}')
+    assert res.status_code == 200
+


### PR DESCRIPTION
## Summary
- build database models with timestamps and indexes
- add Flask-Migrate setup and initial migration
- implement REST API endpoints for quizzes, questions and choices
- include requirements for development and testing
- add tests for models and CRUD API

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*
- `PYTHONPATH=backend pytest -q tests/test_models.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c63de3230832bbf3be5cf187087e3