### PR TITLE
Fix join endpoint validation

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -15,7 +15,10 @@ def _generate_short_code(length=6):
 
 @bp.route('/join/<short_code>', methods=['POST'])
 def join(short_code):
-    name = request.json.get('name')
+    data = request.get_json() or {}
+    name = data.get('name')
+    if not name:
+        return jsonify({'error': 'name is required'}), 400
     quiz = Quiz.query.filter_by(short_code=short_code).first_or_404()
     participant = Participant(name=name, quiz=quiz)
     db.session.add(participant)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -58,3 +58,11 @@ def test_choice_crud(client):
     res = client.delete(f'/api/choices/{choice_id}')
     assert res.status_code == 200
 
+
+def test_join_requires_name(client):
+    qid = create_quiz(client)
+    quiz = Quiz.query.get(qid)
+    res = client.post(f'/join/{quiz.short_code}', json={})
+    assert res.status_code == 400
+    assert 'error' in res.get_json()
+


### PR DESCRIPTION
## Summary
- ensure participant name provided when joining quiz
- add regression test for missing name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d1ea79890832b992a73b0285ce04d